### PR TITLE
Add support for EIP1271

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A library for convenient, universal signature checking for zkSync 2.0.
 
-Currently it only implement ECDSA signature verification, but in the future it will support EIP1271 as well.
+Currently, it is a copy of the OpenZeppelin's [SignatureChecker](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/74738721dc9cfa820687f6b700d2583b16a21c0d/contracts/utils/cryptography/SignatureChecker.sol#L17) library. In the future, it will be slightly edited to avoid emitting warnings about `ecrecover` during compilation.

--- a/contracts/SignatureChecker.sol
+++ b/contracts/SignatureChecker.sol
@@ -1,18 +1,26 @@
 pragma solidity ^0.8.0;
 
 import "./openzeppelin/ECDSA.sol";
+import "./openzeppelin/IERC1271.sol";
 
 library SignatureChecker {
     /** 
      * @dev Checks the signature of an account using ecrecover.
      * In the future, it will use EIP-1271 to validate signatures of AA contracts.
      */
-    function checkSignature(
-        address _address,
-        bytes32 _hash,
-        bytes memory _signature
-    ) pure internal returns (bool) {
-        (address recoveredAddress, ECDSA.RecoverError recoverError) = ECDSA.tryRecover(_hash, _signature);
-        return recoverError == ECDSA.RecoverError.NoError && recoveredAddress == _address;
+    function isValidSignatureNow(
+        address signer,
+        bytes32 hash,
+        bytes memory signature
+    ) internal view returns (bool) {
+        (address recovered, ECDSA.RecoverError error) = ECDSA.tryRecover(hash, signature);
+        if (error == ECDSA.RecoverError.NoError && recovered == signer) {
+            return true;
+        }
+
+        (bool success, bytes memory result) = signer.staticcall(
+            abi.encodeWithSelector(IERC1271.isValidSignature.selector, hash, signature)
+        );
+        return (success && result.length == 32 && abi.decode(result, (bytes4)) == IERC1271.isValidSignature.selector);
     }
 }

--- a/contracts/openzeppelin/IERC1271.sol
+++ b/contracts/openzeppelin/IERC1271.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (interfaces/IERC1271.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC1271 standard signature validation method for
+ * contracts as defined in https://eips.ethereum.org/EIPS/eip-1271[ERC-1271].
+ *
+ * _Available since v4.1._
+ */
+interface IERC1271 {
+    /**
+     * @dev Should return whether the signature provided is valid for the provided data
+     * @param hash      Hash of the data to be signed
+     * @param signature Signature byte array associated with _data
+     */
+    function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4 magicValue);
+}


### PR DESCRIPTION
We couldn't just use built-in [SignatureChecker](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/SignatureChecker.sol) because the warning about the usage of ecrecover would be emitted. We will need our own library to enable removing the warning